### PR TITLE
Freeze markets when UMA proposals happen

### DIFF
--- a/test/UMATriggerFactory.t.sol
+++ b/test/UMATriggerFactory.t.sol
@@ -97,7 +97,7 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
     bytes memory _query
   ) public {
     // Warp forward in time so that if a new query is issued as a result of
-    // settlement it will not have the same block.timestamp as the origainl,
+    // settlement it will not have the same block.timestamp as the original,
     // which will cause the request to fail.
     vm.warp(block.timestamp + 42);
 


### PR DESCRIPTION
This PR makes a few improvements to the UMA trigger:
* only allow YES proposals (there are other non-YES proposals we weren't preventing)
* freeze markets when YES answers are proposed
* re-add authorization to the priceProposed callback
* un-freeze markets if the market resolves to not-YES

It does NOT add titles to UMA queries for the frontend to consume. That will be done [in this ticket](https://linear.app/cozy-finance/issue/ENG-723/require-uma-queries-to-have-titles)