### PR TITLE
Emit trigger metadata in logs

### DIFF
--- a/script/DeployChainlinkPegTrigger.s.sol
+++ b/script/DeployChainlinkPegTrigger.s.sol
@@ -20,6 +20,14 @@ contract DeployChainlinkPegTrigger is Script {
   uint256 priceTolerance = 5000; // 50%
   uint256 frequencyTolerance = 12 hours;
 
+  // The name of the trigger, as it should appear within the Cozy interface.
+  string triggerName = "Peg Protection Trigger";
+
+  // A human-readable description of the intent of the trigger.
+  string triggerDescription = "A trigger that toggles if the asset depegs";
+
+  string triggerLogoURI = "https://s2.coinmarketcap.com/static/img/coins/64x64/8085.png";
+
   // ---------------------------
   // -------- Execution --------
   // ---------------------------
@@ -34,7 +42,18 @@ contract DeployChainlinkPegTrigger is Script {
     console2.log("    frequencyTolerance", frequencyTolerance);
 
     vm.broadcast();
-    ChainlinkTrigger trigger = factory.deployTrigger(pegPrice, decimals, trackingOracle, priceTolerance, frequencyTolerance);
+    ChainlinkTrigger trigger = factory.deployTrigger(
+      pegPrice,
+      decimals,
+      trackingOracle,
+      priceTolerance,
+      frequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        triggerName,
+        triggerDescription,
+        triggerLogoURI
+      )
+    );
     console2.log("ChainlinkTrigger deployed", address(trigger));
   }
 }

--- a/script/DeployChainlinkTrigger.s.sol
+++ b/script/DeployChainlinkTrigger.s.sol
@@ -18,6 +18,14 @@ contract DeployChainlinkTrigger is Script {
   uint256 truthFrequencyTolerance = 1201;
   uint256 trackingFrequencyTolerance = 86401;
 
+  // The name of the trigger, as it should appear within the Cozy interface.
+  string triggerName = "stETH/ETH Trigger";
+
+  // A human-readable description of the intent of the trigger.
+  string triggerDescription = "A trigger that toggles if stETH depegs from ETH";
+
+  string triggerLogoURI = "https://s2.coinmarketcap.com/static/img/coins/64x64/8085.png";
+
   // ---------------------------
   // -------- Execution --------
   // ---------------------------
@@ -32,7 +40,18 @@ contract DeployChainlinkTrigger is Script {
     console2.log("    trackingFrequencyTolerance", trackingFrequencyTolerance);
 
     vm.broadcast();
-    ChainlinkTrigger trigger = factory.deployTrigger(truthOracle, trackingOracle, priceTolerance, truthFrequencyTolerance, trackingFrequencyTolerance);
+    ChainlinkTrigger trigger = factory.deployTrigger(
+      truthOracle,
+      trackingOracle,
+      priceTolerance,
+      truthFrequencyTolerance,
+      trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        triggerName,
+        triggerDescription,
+        triggerLogoURI
+      )
+    );
     console2.log("ChainlinkTrigger deployed", address(trigger));
   }
 }

--- a/script/DeployUMATrigger.s.sol
+++ b/script/DeployUMATrigger.s.sol
@@ -11,15 +11,25 @@ contract DeployUMATrigger is Script {
 
   UMATriggerFactory factory = UMATriggerFactory(0xa48666D91Ac494A3CCA96A3A4357d998d8619387);
 
-  string query = "q: title: Hop Protocol, description: Was there a hack, bug, user error, or malfeasance resulting in a loss or lock-up of tokens in the Hop protocol on Ethereum Mainnet at any point after Ethereum Mainnet block number 114400? This will revert if a 'no' answer is proposed.";
+  string query = "q: title: Was there a Hop Protocol hack?, description: Was there a hack, bug, user error, or malfeasance resulting in a loss or lock-up of tokens in the Hop protocol (https://app.hop.exchange) on Ethereum Mainnet at any point after Ethereum Mainnet block number 114400? This will revert if a non-YES answer is proposed.";
 
   IERC20 rewardToken = IERC20(0x7F5c764cBc14f9669B88837ca1490cCa17c31607);
 
   uint256 rewardAmount = 5e6;
 
-  uint256 bondAmount = 5e6;
+  // It's recommended that the bond be at least twice as high as the reward.
+  uint256 bondAmount = 10e6;
 
-  uint256 proposalDisputeWindow = 1 hours;
+  // A long dispute window is recommended.
+  uint256 proposalDisputeWindow = 2 days;
+
+  // The name of the trigger, as it should appear within the Cozy interface.
+  string triggerName = "Hop hack trigger";
+
+  // A human-readable description of the intent of the trigger.
+  string triggerDescription = "A trigger that toggles if the Hop protocol is hacked";
+
+  string triggerLogoURI = "https://twitter.com/HopProtocol/photo";
 
   // ---------------------------
   // -------- Execution --------
@@ -33,12 +43,54 @@ contract DeployUMATrigger is Script {
     console2.log("    rewardAmount", rewardAmount);
     console2.log("    bondAmount", bondAmount);
     console2.log("    proposalDisputeWindow", proposalDisputeWindow);
+    console2.log("    triggerName", triggerName);
+    console2.log("    triggerDescription", triggerDescription);
+    console2.log("    triggerLogoURI", triggerLogoURI);
 
-    vm.broadcast();
-    rewardToken.approve(address(factory), rewardAmount);
+    // Check to see if a trigger has already been deployed with your desired configs.
+    address _availableTrigger = factory.findAvailableTrigger(
+      query,
+      rewardToken,
+      rewardAmount,
+      bondAmount,
+      proposalDisputeWindow
+    );
 
-    vm.broadcast();
-    UMATrigger trigger = factory.deployTrigger(query, rewardToken, rewardAmount, bondAmount, proposalDisputeWindow);
-    console2.log("UMATrigger deployed", address(trigger));
+    if (_availableTrigger == address(0)) {
+
+      // There is no available trigger that has your desired configuration. We will
+      // have to deploy a new one! First we approve the factory to transfer the
+      // reward for us.
+      vm.broadcast();
+      rewardToken.approve(address(factory), rewardAmount);
+
+      // Then we deploy the trigger.
+      vm.broadcast();
+      _availableTrigger = address(
+        factory.deployTrigger(
+          query,
+          rewardToken,
+          rewardAmount,
+          bondAmount,
+          proposalDisputeWindow,
+          UMATriggerFactory.TriggerMetadata(
+            triggerName,
+            triggerDescription,
+            triggerLogoURI
+          )
+        )
+      );
+      console2.log("New trigger deployed!");
+
+    } else {
+      // A trigger exactly like the one you wanted already exists!
+      // Since triggers can be re-used, there's no need to deploy a new one.
+      console2.log("Found existing trigger with specified configs");
+    }
+
+    console2.log(
+      "Your UMA trigger is available at this address:",
+      _availableTrigger
+    );
   }
 }

--- a/src/interfaces/IChainlinkTriggerFactoryEvents.sol
+++ b/src/interfaces/IChainlinkTriggerFactoryEvents.sol
@@ -13,6 +13,11 @@ interface IChainlinkTriggerFactoryEvents {
   /// `ChainlinkTrigger.truthFrequencyTolerance()` for more information.
   /// @param trackingFrequencyTolerance The frequencyTolerance that the deployed trigger will have for the tracking oracle. See
   /// `ChainlinkTrigger.trackingFrequencyTolerance()` for more information.
+  /// @param name The name that should be used for markets that use the trigger.
+  /// @param description A human-readable description of the trigger.
+  /// @param logoURI The URI of a logo image to represent the trigger.
+  /// For other attributes, see the docs for the params of `deployTrigger` in
+  /// this contract.
   event TriggerDeployed(
     address trigger,
     bytes32 indexed triggerConfigId,
@@ -20,6 +25,9 @@ interface IChainlinkTriggerFactoryEvents {
     address indexed trackingOracle,
     uint256 priceTolerance,
     uint256 truthFrequencyTolerance,
-    uint256 trackingFrequencyTolerance
+    uint256 trackingFrequencyTolerance,
+    string name,
+    string description,
+    string logoURI
   );
 }

--- a/test/ChainlinkTriggerFactory.t.sol
+++ b/test/ChainlinkTriggerFactory.t.sol
@@ -94,7 +94,12 @@ contract DeployTriggerForkTest is ChainlinkTriggerFactoryTestBaseSetup {
       AggregatorV3Interface(_trackingOracle),
       0.1e4, // priceTolerance.
       45, // truthFrequencyTolerance.
-      45 // trackingFrequencyTolerance
+      45, // trackingFrequencyTolerance
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Peg Protection Trigger",
+        "A trigger that protects from something depegging",
+        "https://via.placeholder.com/150"
+      )
     );
   }
 
@@ -127,7 +132,12 @@ contract DeployTriggerForkTest is ChainlinkTriggerFactoryTestBaseSetup {
         AggregatorV3Interface(_trackingOracle),
         _priceTolerance,
         _truthFrequencyTolerance,
-        _trackingFrequencyTolerance
+        _trackingFrequencyTolerance,
+        ChainlinkTriggerFactory.TriggerMetadata(
+          "Chainlink Trigger",
+          "A trigger that compares prices on Chainlink against a threshold",
+          "https://via.placeholder.com/150"
+        )
       );
       assertEq(_trigger.truthFrequencyTolerance(), _truthFrequencyTolerance);
     } else {
@@ -137,7 +147,12 @@ contract DeployTriggerForkTest is ChainlinkTriggerFactoryTestBaseSetup {
         _pegDecimals,
         AggregatorV3Interface(_trackingOracle),
         _priceTolerance,
-        _trackingFrequencyTolerance
+        _trackingFrequencyTolerance,
+        ChainlinkTriggerFactory.TriggerMetadata(
+          "Peg Protection Trigger",
+          "A trigger that protects from something depegging",
+          "https://via.placeholder.com/150"
+        )
       );
       AggregatorV3Interface _pegOracle = _trigger.truthOracle();
       (,int256 _priceInt,,,) = _pegOracle.latestRoundData();
@@ -206,7 +221,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(_trigger.getSets().length, 0);
@@ -247,7 +267,10 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       ethUsdOracleMainnet,
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      "Chainlink Trigger",
+      "A trigger that compares prices on Chainlink against a threshold",
+      "https://via.placeholder.com/150"
     );
 
     factory.deployTrigger(
@@ -255,7 +278,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(ethUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
   }
 
@@ -279,7 +307,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(factory.triggerCount(_triggerConfigId), 1);
@@ -289,7 +322,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(factory.triggerCount(_triggerConfigId), 2);
@@ -311,7 +349,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     vm.chainId(_chainId);
@@ -321,7 +364,12 @@ contract DeployTriggerTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertNotEq(address(_triggerA), address(_triggerB));
@@ -348,7 +396,12 @@ contract ComputeTriggerAddressTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(ethUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(_expectedAddress, address(_trigger));
@@ -426,7 +479,12 @@ contract TriggerConfigIdTest is ChainlinkTriggerFactoryTestSetup {
       AggregatorV3Interface(stEthUsdOracleMainnet),
       _priceTolerance,
       _truthFrequencyTolerance,
-      _trackingFrequencyTolerance
+      _trackingFrequencyTolerance,
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Chainlink Trigger",
+        "A trigger that compares prices on Chainlink against a threshold",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(factory.triggerCount(_triggerConfigId), 1);
@@ -459,7 +517,12 @@ contract FindAvailableTriggerTest is ChainlinkTriggerFactoryTestSetup {
         AggregatorV3Interface(stEthUsdOracleMainnet),
         _priceTolerance,
         _truthFrequencyTolerance,
-        _trackingFrequencyTolerance
+        _trackingFrequencyTolerance,
+        ChainlinkTriggerFactory.TriggerMetadata(
+          "Chainlink Trigger",
+          "A trigger that compares prices on Chainlink against a threshold",
+          "https://via.placeholder.com/150"
+        )
       );
       if (i == 0) _initTrigger = _trigger;
     }
@@ -492,7 +555,12 @@ contract FindAvailableTriggerTest is ChainlinkTriggerFactoryTestSetup {
         AggregatorV3Interface(ethUsdOracleMainnet),
         _priceTolerance,
         _truthFrequencyTolerance,
-        _trackingFrequencyTolerance
+        _trackingFrequencyTolerance,
+        ChainlinkTriggerFactory.TriggerMetadata(
+          "Chainlink Trigger",
+          "A trigger that compares prices on Chainlink against a threshold",
+          "https://via.placeholder.com/150"
+        )
       );
       _addMaxSetsToTrigger(_trigger);
     }
@@ -516,7 +584,12 @@ contract DeployPeggedTriggerTest is ChainlinkTriggerFactoryTestSetup {
       8, // Decimals.
       AggregatorV3Interface(usdcUsdOracleMainnet),
       0.001e4, // 0.1% price tolerance.
-      60 // 60s frequency tolerance.
+      60, // 60s frequency tolerance.
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Peg Protection Trigger",
+        "A trigger that protects from something depegging",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(_trigger.state(), CState.ACTIVE);
@@ -539,7 +612,12 @@ contract DeployPeggedTriggerTest is ChainlinkTriggerFactoryTestSetup {
       8, // Decimals.
       AggregatorV3Interface(usdcUsdOracleMainnet),
       0.001e4, // 0.1% price tolerance.
-      60 // 60s frequency tolerance.
+      60, // 60s frequency tolerance.
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Peg Protection Trigger",
+        "A trigger that protects from something depegging",
+        "https://via.placeholder.com/150"
+      )
     );
 
     ChainlinkTrigger _triggerB = factory.deployTrigger(
@@ -547,7 +625,12 @@ contract DeployPeggedTriggerTest is ChainlinkTriggerFactoryTestSetup {
       8, // Decimals.
       AggregatorV3Interface(usdcUsdOracleMainnet),
       0.042e4, // 4.2% price tolerance.
-      360 // 360s frequency tolerance.
+      360, // 360s frequency tolerance.
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Peg Protection Trigger",
+        "A trigger that protects from something depegging",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(_triggerA.truthOracle(), _triggerB.truthOracle());
@@ -558,7 +641,12 @@ contract DeployPeggedTriggerTest is ChainlinkTriggerFactoryTestSetup {
       8, // Decimals.
       AggregatorV3Interface(usdcUsdOracleMainnet),
       0.042e4, // 4.2% price tolerance.
-      360 // 360s frequency tolerance.
+      360, // 360s frequency tolerance.
+      ChainlinkTriggerFactory.TriggerMetadata(
+        "Peg Protection Trigger",
+        "A trigger that protects from something depegging",
+        "https://via.placeholder.com/150"
+      )
     );
 
     // A new peg oracle would need to have been deployed.

--- a/test/UMATriggerFactory.t.sol
+++ b/test/UMATriggerFactory.t.sol
@@ -25,7 +25,10 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
     address indexed rewardToken,
     uint256 rewardAmount,
     uint256 bondAmount,
-    uint256 proposalDisputeWindow
+    uint256 proposalDisputeWindow,
+    string name,
+    string description,
+    string logoURI
   );
 
   function setUp() public virtual override {
@@ -66,7 +69,10 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       address(rewardToken),
       _rewardAmount,
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      "Terra hack trigger",
+      "A trigger that will toggle if Terra is hacked",
+      "https://via.placeholder.com/150"
     );
 
     UMATrigger _trigger = factory.deployTrigger(
@@ -74,7 +80,12 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       rewardToken,
       uint256(_rewardAmount),
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      UMATriggerFactory.TriggerMetadata(
+        "Terra hack trigger",
+        "A trigger that will toggle if Terra is hacked",
+        "https://via.placeholder.com/150"
+      )
     );
 
     assertEq(address(_trigger), _computedTriggerAddress);
@@ -144,7 +155,12 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       rewardToken,
       _rewardAmount,
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      UMATriggerFactory.TriggerMetadata(
+        "XYZ hack trigger",
+        "A trigger that will toggle if XYZ is hacked",
+        "https://via.placeholder.com/150"
+      )
     );
 
     uint256 _queryTimestamp = _trigger.requestTimestamp();
@@ -295,7 +311,12 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       rewardToken,
       uint256(_rewardAmount),
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      UMATriggerFactory.TriggerMetadata(
+        "Terra hack trigger",
+        "A trigger that will toggle if Terra is hacked",
+        "https://via.placeholder.com/150"
+      )
     );
 
     uint256 _queryTimestamp = _trigger.requestTimestamp();
@@ -420,7 +441,12 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       rewardToken,
       uint256(_rewardAmount),
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      UMATriggerFactory.TriggerMetadata(
+        "Mt. Gox hack trigger",
+        "A trigger that will toggle if Mt. Gox is hacked",
+        "https://via.placeholder.com/150"
+      )
     );
     // Ensure that the entire allowance has been spent.
     assertEq(rewardToken.allowance(address(this), address(factory)), 0);
@@ -493,7 +519,12 @@ contract DeployTriggerSharedTest is TriggerTestSetup {
       rewardToken,
       uint256(_rewardAmount),
       _bondAmount,
-      _proposalDisputeWindow
+      _proposalDisputeWindow,
+      UMATriggerFactory.TriggerMetadata(
+        "USDT hack trigger",
+        "A trigger that will toggle if USDT is hacked",
+        "https://via.placeholder.com/150"
+      )
     );
     uint256 _queryTimestamp = block.timestamp;
 


### PR DESCRIPTION
This should be a no-op with respect to the actual triggers and factories' behavior, outside of the actual events emitted