### PR TITLE
Rework UMA settlement

### DIFF
--- a/script/DeployUMATrigger.s.sol
+++ b/script/DeployUMATrigger.s.sol
@@ -62,9 +62,9 @@ contract DeployUMATrigger is Script {
 
     if (_availableTrigger == address(0)) {
 
-      // There is no available trigger that has your desired configuration. We will
-      // have to deploy a new one! First we approve the factory to transfer the
-      // reward for us.
+      // There is no available trigger that has your desired configuration. We
+      // will have to deploy a new one! First we approve the factory to transfer
+      // the reward for us.
       vm.broadcast();
       rewardToken.approve(address(factory), rewardAmount);
 
@@ -78,11 +78,9 @@ contract DeployUMATrigger is Script {
           refundRecipient,
           bondAmount,
           proposalDisputeWindow,
-          UMATriggerFactory.TriggerMetadata(
-            triggerName,
-            triggerDescription,
-            triggerLogoURI
-          )
+          triggerName,
+          triggerDescription,
+          triggerLogoURI
         )
       );
       console2.log("New trigger deployed!");

--- a/script/DeployUMATrigger.s.sol
+++ b/script/DeployUMATrigger.s.sol
@@ -17,6 +17,8 @@ contract DeployUMATrigger is Script {
 
   uint256 rewardAmount = 5e6;
 
+  address refundRecipient = address(0xBEEF);
+
   // It's recommended that the bond be at least twice as high as the reward.
   uint256 bondAmount = 10e6;
 
@@ -41,6 +43,7 @@ contract DeployUMATrigger is Script {
     console2.log("    query", query);
     console2.log("    rewardToken", address(rewardToken));
     console2.log("    rewardAmount", rewardAmount);
+    console2.log("    refundRecipient", refundRecipient);
     console2.log("    bondAmount", bondAmount);
     console2.log("    proposalDisputeWindow", proposalDisputeWindow);
     console2.log("    triggerName", triggerName);
@@ -52,6 +55,7 @@ contract DeployUMATrigger is Script {
       query,
       rewardToken,
       rewardAmount,
+      refundRecipient,
       bondAmount,
       proposalDisputeWindow
     );
@@ -71,6 +75,7 @@ contract DeployUMATrigger is Script {
           query,
           rewardToken,
           rewardAmount,
+          refundRecipient,
           bondAmount,
           proposalDisputeWindow,
           UMATriggerFactory.TriggerMetadata(

--- a/src/UMATrigger.sol
+++ b/src/UMATrigger.sol
@@ -92,9 +92,8 @@ contract UMATrigger is BaseTrigger {
   /// @notice The most recent timestamp that the query was submitted to the UMA oracle.
   uint256 public requestTimestamp;
 
-  /// @notice Whether or not this trigger will enter the TRIGGERED state the
-  /// next time `runProgrammaticCheck` is called.
-  bool public shouldTrigger;
+  /// @notice Default address that will recieve any leftover rewards.
+  address public refundRecipient;
 
   /// @dev Thrown when a negative answer is proposed to the submitted query.
   error InvalidProposal();
@@ -111,12 +110,14 @@ contract UMATrigger is BaseTrigger {
     FinderInterface _oracleFinder,
     string memory _query,
     IERC20 _rewardToken,
+    address _refundRecipient,
     uint256 _bondAmount,
     uint256 _proposalDisputeWindow
   ) BaseTrigger(_manager) {
     oracleFinder = _oracleFinder;
     query = _query;
     rewardToken = _rewardToken;
+    refundRecipient = _refundRecipient;
     bondAmount = _bondAmount;
     proposalDisputeWindow = _proposalDisputeWindow;
 
@@ -238,12 +239,14 @@ contract UMATrigger is BaseTrigger {
     ) revert Unauthorized();
 
     if (_answer == AFFIRMATIVE_ANSWER) {
-      shouldTrigger = true;
+      uint256 _rewardBalance = rewardToken.balanceOf(address(this));
+      if (_rewardBalance > 0) rewardToken.safeTransfer(refundRecipient, _rewardBalance);
+      _updateTriggerState(CState.TRIGGERED);
     } else {
       // If the answer was not affirmative, i.e. "Yes, the protocol was hacked",
-      // the trigger should return to the ACTIVE state. And we need to resubmit our
-      // query so that we are informed if the event we care about happens in the
-      // future.
+      // the trigger should return to the ACTIVE state. And we need to resubmit
+      // our query so that we are informed if the event we care about happens in
+      // the future.
       _updateTriggerState(CState.ACTIVE);
       _submitRequestToOracle(_oracle);
     }
@@ -269,7 +272,9 @@ contract UMATrigger is BaseTrigger {
       requestTimestamp,
       bytes(query)
     );
+
     if (!_oracleHasPrice) revert Unsettleable();
+
     OptimisticOracleV2Interface.Request memory _umaRequest = _oracle.getRequest(
       address(this),
       queryIdentifier,
@@ -277,6 +282,10 @@ contract UMATrigger is BaseTrigger {
       bytes(query)
     );
     if (!_umaRequest.settled) {
+      // Give the reward balance to the caller to make up for gas costs and
+      // incentivize keeping markets in line with trigger state.
+      refundRecipient = msg.sender;
+
       _oracle.settle(
         address(this),
         queryIdentifier,
@@ -285,14 +294,8 @@ contract UMATrigger is BaseTrigger {
       );
     }
 
-    if (shouldTrigger) {
-      // Give the reward balance to the caller to make up for gas costs and
-      // incentivize keeping markets in line with trigger state.
-      uint256 _rewardBalance = rewardToken.balanceOf(address(this));
-      if (_rewardBalance > 0) rewardToken.safeTransfer(msg.sender, _rewardBalance);
-
-      return _updateTriggerState(CState.TRIGGERED);
-    }
+    // If the request settled as a result of this call, trigger.state will have
+    // been updated in the priceSettled callback.
     return state;
   }
 

--- a/src/UMATrigger.sol
+++ b/src/UMATrigger.sol
@@ -92,7 +92,7 @@ contract UMATrigger is BaseTrigger {
   /// @notice The most recent timestamp that the query was submitted to the UMA oracle.
   uint256 public requestTimestamp;
 
-  /// @notice Default address that will recieve any leftover rewards.
+  /// @notice Default address that will receive any leftover rewards.
   address public refundRecipient;
 
   /// @dev Thrown when a negative answer is proposed to the submitted query.

--- a/src/UMATrigger.sol
+++ b/src/UMATrigger.sol
@@ -194,7 +194,7 @@ contract UMATrigger is BaseTrigger {
     // event related to the specific query we care about. It is possible, for
     // example, for multiple queries to be submitted to the oracle that differ
     // only with respect to timestamp. So we want to make sure we know which
-    // query the oracle has settled on an answer to.
+    // query the answer is for.
     if (
       msg.sender != address(_oracle) ||
       _timestamp != requestTimestamp ||

--- a/src/UMATrigger.sol
+++ b/src/UMATrigger.sol
@@ -286,6 +286,7 @@ contract UMATrigger is BaseTrigger {
       // incentivize keeping markets in line with trigger state.
       refundRecipient = msg.sender;
 
+      // `settle` will cause the oracle to call the trigger's `priceSettled` function.
       _oracle.settle(
         address(this),
         queryIdentifier,

--- a/src/UMATriggerFactory.sol
+++ b/src/UMATriggerFactory.sol
@@ -99,6 +99,7 @@ contract UMATriggerFactory {
     // We need to do this because of stack-too-deep errors; there are too many
     // inputs/internal-vars to this function otherwise.
     DeployTriggerVars memory _vars;
+
     _vars.configId = triggerConfigId(
       _query,
       _rewardToken,

--- a/src/UMATriggerFactory.sol
+++ b/src/UMATriggerFactory.sol
@@ -40,6 +40,7 @@ contract UMATriggerFactory {
     string query,
     address indexed rewardToken,
     uint256 rewardAmount,
+    address refundRecipient,
     uint256 bondAmount,
     uint256 proposalDisputeWindow,
     string name,
@@ -68,8 +69,10 @@ contract UMATriggerFactory {
   /// Oracle for evaluation.
   /// @param _rewardToken The token used to pay the reward to users that propose
   /// answers to the query.
-  /// @param _rewardAmount The amount of rewardToken that will be paid to users
-  /// who propose an answer to the query.
+  /// @param _rewardAmount The amount of rewardToken that will be paid as a
+  /// reward to anyone who proposes an answer to the query.
+  /// @param _refundRecipient Default address that will recieve any leftover
+  /// rewards at UMA query settlement time.
   /// @param _bondAmount The amount of `rewardToken` that must be staked by a
   /// user wanting to propose or dispute an answer to the query. See UMA's price
   /// dispute workflow for more information. It's recommended that the bond
@@ -85,6 +88,7 @@ contract UMATriggerFactory {
     string memory _query,
     IERC20 _rewardToken,
     uint256 _rewardAmount,
+    address _refundRecipient,
     uint256 _bondAmount,
     uint256 _proposalDisputeWindow,
     TriggerMetadata memory _metadata
@@ -93,6 +97,7 @@ contract UMATriggerFactory {
       _query,
       _rewardToken,
       _rewardAmount,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow
     );
@@ -103,6 +108,7 @@ contract UMATriggerFactory {
       _query,
       _rewardToken,
       _rewardAmount,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow,
       _triggerCount
@@ -115,6 +121,7 @@ contract UMATriggerFactory {
       oracleFinder,
       _query,
       _rewardToken,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow
     );
@@ -128,6 +135,7 @@ contract UMATriggerFactory {
       _query,
       address(_rewardToken),
       _rewardAmount,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow,
       _metadata.name,
@@ -143,6 +151,7 @@ contract UMATriggerFactory {
     string memory _query,
     IERC20 _rewardToken,
     uint256 _rewardAmount,
+    address _refundRecipient,
     uint256 _bondAmount,
     uint256 _proposalDisputeWindow,
     uint256 _triggerCount
@@ -152,6 +161,7 @@ contract UMATriggerFactory {
       oracleFinder,
       _query,
       _rewardToken,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow
     );
@@ -176,6 +186,7 @@ contract UMATriggerFactory {
     string memory _query,
     IERC20 _rewardToken,
     uint256 _rewardAmount,
+    address _refundRecipient,
     uint256 _bondAmount,
     uint256 _proposalDisputeWindow
   ) public view returns(address) {
@@ -184,6 +195,7 @@ contract UMATriggerFactory {
       _query,
       _rewardToken,
       _rewardAmount,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow
     );
@@ -194,6 +206,7 @@ contract UMATriggerFactory {
         _query,
         _rewardToken,
         _rewardAmount,
+        _refundRecipient,
         _bondAmount,
         _proposalDisputeWindow,
         i
@@ -211,24 +224,33 @@ contract UMATriggerFactory {
   /// @notice Call this function to determine the identifier of the supplied
   /// trigger configuration. This identifier is used both to track the number of
   /// triggers deployed with this configuration (see `triggerCount`) and is
-  /// emitted at the time triggers with that configuration are deployed.
+  /// emitted as a part of the TriggerDeployed event when triggers are deployed.
+  /// @dev This function takes the rewardAmount as an input despite it not being
+  /// an argument of the UMATrigger constructor nor it being held in storage by
+  /// the trigger. This is done because the rewardAmount is something that
+  /// deployers could reasonably differ on. Deployer A might deploy a trigger
+  /// that is identical to what Deployer B wants in every way except the amount
+  /// of rewardToken that is being offered, and it would still be reasonable for
+  /// Deployer B to not want to re-use A's trigger for his own markets.
   function triggerConfigId(
     string memory _query,
     IERC20 _rewardToken,
     uint256 _rewardAmount,
+    address _refundRecipient,
     uint256 _bondAmount,
     uint256 _proposalDisputeWindow
   ) public view returns (bytes32) {
-    bytes memory _triggerConstructorArgs = abi.encode(
+    bytes memory _triggerConfigData = abi.encode(
       manager,
       oracleFinder,
       _query,
       _rewardToken,
       _rewardAmount,
+      _refundRecipient,
       _bondAmount,
       _proposalDisputeWindow
     );
-    return keccak256(_triggerConstructorArgs);
+    return keccak256(_triggerConfigData);
   }
 
   function _getSalt(


### PR DESCRIPTION
There are a few changes here:
* adds a `refundRecipient` constructor arg to the trigger
* removes TriggerMetadata struct in factory
* updates markets within the `priceSettled` callback
* refunds leftover rewards within the `priceSettled` callback